### PR TITLE
Updated posts will display date

### DIFF
--- a/content/blog/2021/02-28-copyrighting-music/index.mdx
+++ b/content/blog/2021/02-28-copyrighting-music/index.mdx
@@ -115,7 +115,7 @@ Six days later I'm wondering, "Where's my copyrights?!" which lead me to finding
 
 ## Success!
 
-Received an official document in the mail on June 7, 2021!
+Submitted the forms on February 22, 2021 and received an official document in the mail on June 7, 2021. So, a bit over 3 months. Not bad for 2021 I say!
 
 ##### Attributions
 

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -7,23 +7,30 @@ export const LinkWrapper = tw(Link)`
   rounded-lg mt-4 hover:(ring-2 ring-primary)
 `
 
+export const updatedWrapper = tw.p`
+  m-0
+`
+
 export const PostCard = ({ post, collection }) => (
   <LinkWrapper to={`/${collection}/${post.node.frontmatter.slug}`}>
-    <div key={post.node.id} className='flex flex-col sm:flex-row rounded-lg shadow-lg bg-surface p-4 h-full'>
+    <div key={post.node.id} className='flex flex-col h-full p-4 rounded-lg shadow-lg sm:flex-row bg-surface'>
       {post.node.frontmatter.coverImage ? (
         <Img
-          className='absolute top-0 left-0 w-auto h-auto sm:w-36 sm:h-24 flex-none'
+          className='absolute top-0 left-0 flex-none w-auto h-auto sm:w-36 sm:h-24'
           fluid={post.node.frontmatter.coverImage.childImageSharp.fluid}
         />
       ) : (
         <div className='bg-brandedSurface sm:w-36 sm:h-24'></div>
       )}
-      <div className='sm:ml-4 mt-2 sm:mt-0 relative flex flex-col justify-between'>
+      <div className='relative flex flex-col justify-between mt-2 sm:ml-4 sm:mt-0'>
         <div>
           <h2>{post.node.frontmatter.title}</h2>
           <p className='mt-1'>{post.node.excerpt}</p>
         </div>
         <p className='text-sm text-muted'>{post.node.frontmatter.date}</p>
+        {post.node.frontmatter.updated ? (
+          <updatedWrapper className='text-sm text-muted'>Updated: {post.node.frontmatter.updated}</updatedWrapper>
+        ) : null}
       </div>
     </div>
   </LinkWrapper>

--- a/src/templates/post-list.js
+++ b/src/templates/post-list.js
@@ -7,9 +7,7 @@ import SEO from '../components/seo'
 import { Layout, CoverImage, Content, PostCard, Pagination } from '../components'
 
 const PostContainer = styled.div(
-  tw`
-    grid gap-y-0 lg:grid-cols-2 lg:gap-x-4 lg:pb-4
-  `
+  tw`grid  gap-y-0 lg:grid-cols-2 lg:gap-x-4 lg:pb-4`
 )
 
 const postList = ({ pageContext, data }) => {
@@ -56,6 +54,7 @@ export const pageQuery = graphql`
             slug
             title
             date(formatString: "MMMM D, YYYY")
+            updated(formatString: "MMMM D, YYYY")
             excerpt
             coverImage {
               publicURL

--- a/src/templates/single-post.js
+++ b/src/templates/single-post.js
@@ -53,7 +53,7 @@ const BlogPost = ({ data, pageContext }) => {
     <Layout>
       <SEO title={frontmatter.title} description={frontmatter.excerpt} />
       <CoverImage fluid={coverImage} />
-      <div className='flex items-center justify-between text-xs lg:items-start lg:text-sm text-muted mt-1 ml-2 lg:ml-0 mr-2 lg:mr-0'>
+      <div className='flex items-center justify-between mt-1 ml-2 mr-2 text-xs lg:items-start lg:text-sm text-muted lg:ml-0 lg:mr-0'>
         <InfoWrapper>
           <span>Posted </span>
           <InfoSeparator>:&nbsp;</InfoSeparator>
@@ -69,10 +69,11 @@ const BlogPost = ({ data, pageContext }) => {
       <Content>
         <h1>
           {frontmatter.draft && (
-            <span className='bg-opposite rounded-lg p-2 inline-block uppercase tracking-wide'>(Draft)</span>
+            <span className='inline-block p-2 tracking-wide uppercase rounded-lg bg-opposite'>(Draft)</span>
           )}{' '}
           {frontmatter.title}
         </h1>
+        {frontmatter.updated ? <p className='mt-1 text-sm text-muted'>Updated: {frontmatter.updated}</p> : null}
         <MDXRenderer>{data.mdx.body}</MDXRenderer>
       </Content>
       <LinkEdges prevPage={prevPost} nextPage={nextPost} collection={collection} />
@@ -88,6 +89,7 @@ export const blogQuery = graphql`
       body
       frontmatter {
         date(formatString: "MM/DD/YYYY")
+        updated(formatString: "MM/DD/YYYY")
         excerpt
         slug
         title


### PR DESCRIPTION
On the card, it will display Updated: under the post date.
On the post itself, it will display Updated: under the title.

There were some opinionated fixes that happened when I saved files.
Just some minor formatting things.

*Also* added some clearer text to blog post on Copyrighting Music that I had ***just*** created!