### PR TITLE
Add import for graphql in gatsby-node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,5 @@
+const graphql = require('gatsby').graphql
+
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNode, createNodeField } = actions
   if (node.internal.type === `MarkdownRemark` || node.internal.type === 'Mdx') {


### PR DESCRIPTION
This is a requirement for Gatsby 3 and it is fine in Gatsby 2.