### PR TITLE
SVG wrappers

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -141,12 +141,12 @@ const GlobalStyles = createGlobalStyle`
     background-color: rgba(var(--primary-rgb), var(--th-opacity));
   }
 
-  svg {
+  /* svg {
     width: 100%;
     height: auto;
     fill: currentColor;
     pointer-events: none;
-  }
+  } */
 
   /* Footnotes */
   .footnote-ref {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -141,13 +141,6 @@ const GlobalStyles = createGlobalStyle`
     background-color: rgba(var(--primary-rgb), var(--th-opacity));
   }
 
-  /* svg {
-    width: 100%;
-    height: auto;
-    fill: currentColor;
-    pointer-events: none;
-  } */
-
   /* Footnotes */
   .footnote-ref {
     color: var(--primary);

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,15 +1,9 @@
 import { Link } from 'gatsby'
 import * as React from 'react'
 import { useContext } from 'react'
-import styled from 'styled-components'
 
 import { DarkToggle, MenuContext, MenuItem } from '.'
 import { Logo, Hamburger, X } from '../svgs'
-
-const LogoWrapper = styled.div`
-  height: 45px;
-  width: 155.45px;
-`
 
 export const Header = ({ siteTitle }) => {
   const { menuOpen, setMenuOpen } = useContext(MenuContext)
@@ -18,9 +12,7 @@ export const Header = ({ siteTitle }) => {
       <div className='flex items-center justify-between px-4 py-3 sm:p-0'>
         <h1>
           <Link to='/'>
-            <LogoWrapper>
-              <Logo siteTitle={siteTitle} />
-            </LogoWrapper>
+            <Logo siteTitle={siteTitle} />
           </Link>
         </h1>
         <div className='sm:hidden'>
@@ -34,7 +26,11 @@ export const Header = ({ siteTitle }) => {
           </button>
         </div>
       </div>
-      <nav className={`absolute w-full sm:static sm:w-auto sm:block ${menuOpen ? ' block' : ' hidden'}`}>
+      <nav
+        className={`absolute w-full sm:static sm:w-auto sm:block ${
+          menuOpen ? ' block' : ' hidden'
+        }`}
+      >
         <div className='w-full sm:flex sm:p-0 bg-container border-fadeaway sm:border-none'>
           <MenuItem href='/blog' first='true'>
             Blog

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -4,7 +4,7 @@ import { Image } from '../components'
 export const Hero = () => (
   <>
     <div className='relative h-64 m-0 overflow-hidden rounded-lg bg-brandedSurface dark:bg-opposite'>
-      <div className='absolute z-30 flex w-full h-full items-center'>
+      <div className='absolute z-30 flex items-center w-full h-full'>
         <div className='relative z-30 w-5/6 px-6 py-8 text-body md:py-6 md:w-1/2'>
           <div className='hidden md:inline'>
             <h2 className='text-3xl lg:text-5xl'>
@@ -31,8 +31,8 @@ export const Hero = () => (
           <span></span>
         </div>
         <div className='absolute top-0 right-0 flex w-full h-full'>
-          <div className='sm:w-1/3 w-14 h-full bg-brandedSurface dark:bg-opposite transition-all'></div>
-          <div className='relative w-1/3'>
+          <div className='h-full transition-all sm:w-1/3 w-14 bg-brandedSurface dark:bg-opposite'></div>
+          <div className='relative w-1/3 w-288 h-288'>
             <svg
               fill='currentColor'
               viewBox='0 0 100 100'
@@ -51,7 +51,10 @@ export const Hero = () => (
         </div>
       </div>
       <div className='absolute top-0 right-0 block w-8/12 h-full'>
-        <Image className='object-cover min-w-full h-full' alt='Synthesizer - photo by Steve Harvey @ Unsplash' />
+        <Image
+          className='object-cover h-full min-w-full'
+          alt='Synthesizer - photo by Steve Harvey @ Unsplash'
+        />
       </div>
     </div>
   </>

--- a/src/svgs/Chevrons.js
+++ b/src/svgs/Chevrons.js
@@ -1,33 +1,54 @@
 import * as React from 'react'
+import styled from 'styled-components'
 
+const ChevronWrapper = styled.div`
+  height: 21px;
+  width: 21px;
+`
 export const DoubleChevronLeft = () => (
-  <svg className='inline fill-current' height='21' viewBox='0 0 21 21' width='21' xmlns='http://www.w3.org/2000/svg'>
-    <g
-      fill='none'
-      fill-rule='evenodd'
-      stroke='var(--text-body)'
-      stroke-linecap='round'
-      stroke-linejoin='round'
-      transform='translate(5 6)'
+  <ChevronWrapper>
+    <svg
+      className='inline fill-current'
+      height='21'
+      viewBox='0 0 21 21'
+      width='21'
+      xmlns='http://www.w3.org/2000/svg'
     >
-      <path d='m8.5 8.5-4-4 4-4' />
-      <path d='m4.5 8.5-4-4 4-4' />
-    </g>
-  </svg>
+      <g
+        fill='none'
+        fill-rule='evenodd'
+        stroke='var(--text-body)'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+        transform='translate(5 6)'
+      >
+        <path d='m8.5 8.5-4-4 4-4' />
+        <path d='m4.5 8.5-4-4 4-4' />
+      </g>
+    </svg>
+  </ChevronWrapper>
 )
 
 export const DoubleChevronRight = () => (
-  <svg className='inline fill-current' height='21' viewBox='0 0 21 21' width='21' xmlns='http://www.w3.org/2000/svg'>
-    <g
-      fill='none'
-      fill-rule='evenodd'
-      stroke='var(--text-body)'
-      stroke-linecap='round'
-      stroke-linejoin='round'
-      transform='translate(7 6)'
+  <ChevronWrapper>
+    <svg
+      className='inline fill-current'
+      height='21'
+      viewBox='0 0 21 21'
+      width='21'
+      xmlns='http://www.w3.org/2000/svg'
     >
-      <path d='m.5 8.5 4-4-4-4' />
-      <path d='m4.5 8.5 4-4-4-4' />
-    </g>
-  </svg>
+      <g
+        fill='none'
+        fill-rule='evenodd'
+        stroke='var(--text-body)'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+        transform='translate(7 6)'
+      >
+        <path d='m.5 8.5 4-4-4-4' />
+        <path d='m4.5 8.5 4-4-4-4' />
+      </g>
+    </svg>
+  </ChevronWrapper>
 )

--- a/src/svgs/Hamburger.js
+++ b/src/svgs/Hamburger.js
@@ -1,10 +1,18 @@
 import * as React from 'react'
+import styled from 'styled-components'
+
+const HamburgerWrapper = styled.div`
+  height: 45px;
+  width: 45px;
+`
 
 export const Hamburger = () => (
-  <svg class='h-6 w-6 fill-current' viewBox='0 0 24 24'>
-    <path
-      fill-rule='evenodd'
-      d='M4 5h16a1 1 0 0 1 0 2H4a1 1 0 1 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2z'
-    />
-  </svg>
+  <HamburgerWrapper>
+    <svg class='h-6 w-6 fill-current' viewBox='0 0 24 24'>
+      <path
+        fill-rule='evenodd'
+        d='M4 5h16a1 1 0 0 1 0 2H4a1 1 0 1 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2z'
+      />
+    </svg>
+  </HamburgerWrapper>
 )

--- a/src/svgs/Logo.js
+++ b/src/svgs/Logo.js
@@ -1,33 +1,29 @@
 import * as React from 'react'
+import styled from 'styled-components'
+
+const LogoWrapper = styled.div`
+  height: 45px;
+  width: 155.45px;
+`
 
 export const Logo = ({ siteTitle }) => (
-  <svg
-    aria-labelledby={siteTitle}
-    title={`${siteTitle} Logo`}
-    className='fill-current h-10'
-    xmlns='http://www.w3.org/2000/svg'
-    viewBox='0 0 38 11'
-  >
-    <defs />
-    <text
-      x='.094'
-      y='8.977'
-      stroke-width='.265'
-      font-family='Lato'
-      font-size='10.583'
-      font-weight='400'
-      class='text-header'
-      style={{
-        lineHeight: 1.25,
-        fontVariantLigatures: 'normal',
-        fontVariantCaps: 'normal',
-        fontVariantNumeric: 'normal',
-        fontVariantEastAsian: 'normal',
-      }}
+  <LogoWrapper>
+    <svg
+      aria-labelledby={siteTitle}
+      title={`${siteTitle} Logo`}
+      className='h-10 fill-current'
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox='0 0 38 11'
     >
-      <tspan
+      <defs />
+      <text
         x='.094'
         y='8.977'
+        stroke-width='.265'
+        font-family='Lato'
+        font-size='10.583'
+        font-weight='400'
+        class='text-header'
         style={{
           lineHeight: 1.25,
           fontVariantLigatures: 'normal',
@@ -36,9 +32,21 @@ export const Logo = ({ siteTitle }) => (
           fontVariantEastAsian: 'normal',
         }}
       >
-        KoaMar
-      </tspan>
-    </text>
-    <path className='text-primary' d='M13 10.3 L 32.5,10.1 L 32.5, 10.5 z' />
-  </svg>
+        <tspan
+          x='.094'
+          y='8.977'
+          style={{
+            lineHeight: 1.25,
+            fontVariantLigatures: 'normal',
+            fontVariantCaps: 'normal',
+            fontVariantNumeric: 'normal',
+            fontVariantEastAsian: 'normal',
+          }}
+        >
+          KoaMar
+        </tspan>
+      </text>
+      <path className='text-primary' d='M13 10.3 L 32.5,10.1 L 32.5, 10.5 z' />
+    </svg>
+  </LogoWrapper>
 )

--- a/src/svgs/X.js
+++ b/src/svgs/X.js
@@ -1,14 +1,26 @@
 import * as React from 'react'
+import styled from 'styled-components'
 
+const XWrapper = styled.div`
+  height: 45px;
+  width: 45px;
+`
 export const X = () => (
-  <svg
-    className='h-6 w-6 fill-current'
-    xmlns='http://www.w3.org/2000/svg'
-    fill='none'
-    viewBox='0 0 24 24'
-    stroke='currentColor'
-    aria-hidden='true'
-  >
-    <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 18L18 6M6 6l12 12' />
-  </svg>
+  <XWrapper>
+    <svg
+      className='w-6 h-6 fill-current'
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 24 24'
+      stroke='currentColor'
+      aria-hidden='true'
+    >
+      <path
+        stroke-linecap='round'
+        stroke-linejoin='round'
+        stroke-width='2'
+        d='M6 18L18 6M6 6l12 12'
+      />
+    </svg>
+  </XWrapper>
 )


### PR DESCRIPTION
The problem I started having after some minor Gatsby updates (but still Gatsby 2) caused me to jump to conclusions and implement some untested SVG `CSS` in App.js. I thought it had fixed the only problem I had, the Logo jumping out at a huge size and then shrinking back without giving up space. It gave the first load of the site a less than professional look. Not that I want to be a professional :) I'm retired! I've ripped that out, but I've still put in the height and width on all the SVGs. Hopefully, I can take that out someday. Why must I do that really? It looked perfect before I had to update to fix some security issues. I really need to get the update to the newest Gatsby going again!