### PR TITLE
Fix markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Menus, dark mode, landing pages for the different content sections, all done. Co
 - [Responsive header in Tailwind CSS - DEV](https://dev.to/dailydevtips1/responsive-header-in-tailwind-css-2djn) by [Chris Bongers](https://dev.to/dailydevtips1) I thought this was a fun idea so I used it a bit!
 - [lekoarts](https://www.lekoarts.de/en/) So many things... code syntax highlighting, creating good draft support, probably more!
 - [Creating Linked Blog Post Headers using MDX on GatsbyJS. - Coner Murphy](https://conermurphy.com/blog/blog-post-linked-headers-mdx-gatsbyjs/) - not only did this work, but, I started thinking about doing more with the components for Mdx.
+- [Styling External Links with an Icon in CSS](https://christianoliff.com/blog/styling-external-links-with-an-icon-in-css/) by [Christian Oliff](https://christianoliff.com/)
 
 ## Using
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -184,9 +184,7 @@ const GlobalStyles = createGlobalStyle`
     text-decoration: none;
   }
 
-  .standalone-link:hover {
-    color: var(--primary);
-  }
+  .standalone-link:hover,
   .standalone-link:focus {
     color: var(--primary);
   }  

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -188,6 +188,18 @@ const GlobalStyles = createGlobalStyle`
   .standalone-link:focus {
     color: var(--primary);
   }  
+
+  .external-link::after {
+    content: "";
+    width: 11px;
+    height: 11px;
+    margin-left: 4px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    display: inline-block; 
+  }
 `
 
 export const App = ({ children }) => {

--- a/src/components/ExternalLink.js
+++ b/src/components/ExternalLink.js
@@ -1,7 +1,12 @@
 import * as React from 'react'
 
 export const ExternalLink = ({ href, children }) => (
-  <a href={href} className='inline-link border-fadeaway' target='_blank' rel='noreferrer noopener nofollow'>
+  <a
+    href={href}
+    className='inline-link external-link border-fadeaway'
+    target='_blank'
+    rel='noreferrer noopener nofollow'
+  >
     {children}
   </a>
 )

--- a/src/components/MarkdownLink.js
+++ b/src/components/MarkdownLink.js
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import PropTypes from 'prop-types'
-import { Link as GatsbyLink } from 'gatsby'
-import { InternalLink } from '.'
+import { InternalLink, ExternalLink } from '.'
 
 // Checks against absolute URLs that share 👇 so we can still pass it along to Gatsby's internal link component
 const domainRegex = /http[s]*:\/\/[www.]*koamar\.com[/]?/
@@ -30,16 +29,7 @@ export const MarkdownLink = ({ href, ...rest }) => {
     return <a href={href} {...rest} /> // eslint-disable-line jsx-a11y/anchor-has-content
   }
 
-  return (
-    <a
-      data-link-external
-      href={href}
-      className='inline-link border-fadeaway'
-      target='_blank'
-      rel='noopener noreferrer nofollow'
-      {...rest}
-    />
-  )
+  return <ExternalLink href={href} {...rest} />
 }
 
 MarkdownLink.propTypes = {

--- a/src/components/MarkdownLink.js
+++ b/src/components/MarkdownLink.js
@@ -15,18 +15,12 @@ export const MarkdownLink = ({ href, ...rest }) => {
     href = href.replace(domainRegex, '/')
   }
 
-  if (href.startsWith('/')) {
-    return (
-      <GatsbyLink
-        className='font-semibold rounded hover:bg-opposite'
-        data-link-internal
-        to={href}
-        {...rest}
-      />
-    )
-  }
-
-  if (href.startsWith('#') || href.startsWith('../') || href.startsWith('./')) {
+  if (
+    href.startsWith('#') ||
+    href.startsWith('../') ||
+    href.startsWith('./') ||
+    href.startsWith('/')
+  ) {
     // return <a href={href} {...rest} />
     return <InternalLink href={href} {...rest} />
   }


### PR DESCRIPTION
- Cleaned up some code related to internal links
- Using `ExternalLink` component
- No more need for Link from Gatsby inside of `MarkdownLink`
- Since all external links use the same component now, it is easier to add a little fun to them. A little icon showing the user when they activate that link, it will go outside the system.