### PR TITLE
Alt for images

### DIFF
--- a/content/blog/2021/02-28-copyrighting-music/index.mdx
+++ b/content/blog/2021/02-28-copyrighting-music/index.mdx
@@ -4,6 +4,7 @@ slug: copyrighting-music
 date: 2021-02-28
 updated: 2022-01-10
 coverImage: ./copyright-photo.jpg
+coverAlt: Piece of sheet music on a keyboard displaying the copyright prominently
 excerpt: A walk-through on the Copyrighting process here in USA.
 tags: [music, copyright]
 ---
@@ -28,9 +29,10 @@ My only positive reason, and I consider it the main reason to register, is I wan
 What are some reasons **_you_** might have for copyrighting your music?
 
 <Warning>
-  Think about how you'd feel if one of your tunes showed up on the Internet with someone saying they wrote it? What if
-  you heard it promoting a product you didn't like? What if a high ranking politician used it at some sort of, oh, I
-  don't know, rally without your okay (or even with you explicitly telling them they most definitely did not have the
+  Think about how you'd feel if one of your tunes showed up on the Internet with someone
+  saying they wrote it? What if you heard it promoting a product you didn't like? What if
+  a high ranking politician used it at some sort of, oh, I don't know, rally without your
+  okay (or even with you explicitly telling them they most definitely did not have the
   right)? You'd want some legal backing to show that you wrote the tune, right?
 </Warning>
 
@@ -49,14 +51,13 @@ Right at the top, is a note about registering a group of unpublished works. Hey,
 First step is to Log In to the Electronic Copyright Office (eCO) Registration System by clicking on the button with that same name!
 
 <Info>
-  Have you noticed that on government websites buttons are really long? I used to work in local government and it seemed
-  the norm.
+  Have you noticed that on government websites buttons are really long? I used to work in
+  local government and it seemed the norm.
 </Info>
 
 You'll need to create an account first. But, once you are logged in, you've got a multitude of menu options to look over! Amongst those is "Register a Group of Unpublished Works" which you should by all means click!
 
 <Warning>
-
 
 ### Strange Message
 
@@ -65,7 +66,6 @@ performance when used with the eCO system." Well, it seems fine on Chrome and Ed
 browsers installed to try at the moment.
 
 </Warning>
-
 
 There **_is_** a video you can watch that goes through all the minutia of registering your group of unpublished works for copyright. I did end up watching bits of that as some aspects of the process were not as clear as I thought. I wanted to put "&copy Year Koamuse - All rights reserved" at the bottom of my tunes. It seems what people do instead of putting just their name. There were places in the form asking for Organization Name. When I did try to enter this, hoping it would just have it in there as well as my name, it told me I must say it is a work for hire. None of these are though. I'm still using _Koamuse_ on the sheet music like I want but there is no mention of it in the copyright registration I filled out. It is on the files I've submitted though. I hope that isn't wrong!
 
@@ -83,13 +83,11 @@ There's a place to enter the year of registration. The site states you should pu
 
 <Success>
 
-
 ### 🔥 Hot Tip 🔥
 
 Pick the song you want to be the **_main_** one first. When you are done, the title will be that one and however many Other Published Works. For me, it was _Safe and 6 Other Unpublished Works_.
 
 </Success>
-
 
 ## Paying
 

--- a/content/blog/2022/02-07-creating-code-system/index.mdx
+++ b/content/blog/2022/02-07-creating-code-system/index.mdx
@@ -3,19 +3,18 @@ title: Creating a Code System for Gatsby
 slug: create-code-system
 date: 2022-02-07
 coverImage: ./sean-lim-NPlv2pkYoUA-unsplash.jpg
+coverAlt: Laptop screen displaying a code editor in foreground with a blurred city scene in the background
 excerpt: How I created the code system for my blog
 tags: [css, mdx, react, gatsby]
 ---
 
 <Warning>
 
-
 ## Gatsby 2 warning
 
 This was done some time ago and it was Gatsby 2 at the time. I haven't updated my blog yet so I'm not sure what if anything would be required.
 
 </Warning>
-
 
 My goal was to create a system for code examples that supports everything [Lekoarts](https://www.lekoarts.de/) has done in a way that I can understand and control. I know I've added bits to this system on my blog but so much of it is what was in the original Code.js file. I must acknowledge how awesome that was!
 
@@ -385,11 +384,9 @@ export const TitleContainer = styled.div`
 
 <Success>
 
-
 To include spaces, use a non-breaking space `&nbsp;` like the good 'ole days!
 
 </Success>
-
 
 ## Copy Code Button
 
@@ -452,13 +449,11 @@ export const CopyCode = styled.button`
 
 <Warning>
 
-
 ### Code.js is newer!
 
 All the following is slightly different code because it is from a different codebase. I didn't get all the features working in my test project, but in my blog, they work&mdash;mostly.
 
 </Warning>
-
 
 ```jsx:title=Updated Code.js noLineNumbers
 // Add import

--- a/content/blog/code-test/index.mdx
+++ b/content/blog/code-test/index.mdx
@@ -3,6 +3,7 @@ title: Code Tests
 slug: code-test
 date: 2020-12-22
 coverImage: ./nasa-Q1p7bh3SHj8-unsplash.jpg
+coverAlt: Part of the earth at night showing lit up cities and the aurora borealis can be seen
 excerpt: Code tests for rendering
 tags: [mdx, test, code, table]
 created: 2020-01-01
@@ -14,7 +15,12 @@ import SpotifyPlayer from './SpotifyPlayer'
 
 Imported React Component
 
-<SpotifyPlayer uri='spotify:user:bbcamerica:playlist:3w18u69NplCpXVG4fQG726' size='large' theme='black' view='list' />
+<SpotifyPlayer
+  uri='spotify:user:bbcamerica:playlist:3w18u69NplCpXVG4fQG726'
+  size='large'
+  theme='black'
+  view='list'
+/>
 
 Live Code Example with title
 
@@ -149,7 +155,10 @@ Some GraphQL
 
 ```graphql
 query SITE_INDEX_QUERY {
-  allMdx(sort: { fields: [frontmatter___date], order: DESC }, filter: { frontmatter: { published: { eq: true } } }) {
+  allMdx(
+    sort: { fields: [frontmatter___date], order: DESC }
+    filter: { frontmatter: { published: { eq: true } } }
+  ) {
     nodes {
       id
       excerpt(pruneLength: 250)

--- a/content/blog/first-fake/index.mdx
+++ b/content/blog/first-fake/index.mdx
@@ -3,6 +3,7 @@ title: Hello World!
 slug: first-fake
 date: 2020-12-19
 coverImage: ./nature.jpg
+coverAlt: A forest with many trees, the foreground dark, and sunlight filtering through the trees in the distance
 excerpt: Mdx tests for rendering
 tags: [mdx, test, code, table]
 ---

--- a/content/blog/second-fake/index.mdx
+++ b/content/blog/second-fake/index.mdx
@@ -3,6 +3,7 @@ title: Write Good Tests
 slug: second-fake
 date: 2020-12-20
 coverImage: ./mountain.jpg
+coverAlt: Mountains stretching off into the distance at dusk, the sky goes from dark blue to light purple in the distance
 excerpt: Here's some example text
 tags: [test, write-good]
 ---
@@ -15,7 +16,6 @@ Here's some example text hoping to get some suggestions from the write-good exte
 
 <Warning>
 
-
 # Wimpy Word Test level 1
 
 Well, it doesn't like the word spelled R-E-A-L-L-Y as a whole sentence or a <em>word</em>{' '}
@@ -24,13 +24,11 @@ words I don't want to give them up! Link color testing with [a link to Google](h
 
 </Warning>
 
-
 It doesn't catch crazy grammar errors. Spelling errors? How am I supposed to write good if this doesn't help me?
 
 It took the ability to flag incorrect writing for me in certain situations. However...
 
 <Success>
-
 
 ## MD Test level 2
 
@@ -44,11 +42,9 @@ Checking for lexical illusions is is fun insofar as it works. Link color testing
 
 </Success>
 
-
 There is something to be said for this. There are things to consider here. It must be a weasel word.
 
 <Info>
-
 
 ### Text formatting level 3
 
@@ -61,11 +57,9 @@ Just checking on spacing around multiple headers in a text block. And aha!
 
 </Info>
 
-
 I suppose I could configure it to stop warning me about weasel words and just let me know when I'm talking in passive too much. But isn't there a time for that even? Grammar Police? A little help here?
 
 <Danger>
-
 
 #### Danger level 4
 
@@ -76,7 +70,6 @@ would look terrible in dark mode! Well, it's not that terrible.
 
 </Danger>
 
-
 Need a spell checker for markdown.
 
 Oh, I have one... [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). I hadn't turned it on. **_Such embarrassment!_**
@@ -85,18 +78,15 @@ Ah, and write-good does look at mdx files now that I've configured it.
 
 <Primary>
 
-
 ##### Go Sharks! level 5
 
 2020-2021 season not going so well. 3 wins, 5 losses so far. Link color testing with [a link to San Jose Sharks](https://www.nhl.com/sharks).
 
 </Primary>
 
-
 This is an info test for a text block with some markdown formatting but no header required.
 
 <Info>
-
 
 An informative item with **_markdown_** formatting (minor such that it is) to see what it looks like without a header. So, if I want any markdown formatting, I'd better have a header. I'm sure there is a CSS trick to make the margin-top go away for a paragraph but only when it is the first item in this container! Sounds an awful lot like :first-child but I couldn't get it to work. I'll keep trying.
 
@@ -107,7 +97,6 @@ Three paragraphs.
 Okay, nth-child(2)? **_Really?_** 😅 So, if the second child is a paragraph (it is 1-based), that means there is no header and I should scrap the margin-top on _this_ paragraph.
 
 </Info>
-
 
 Oh goodness, I get it actually! Oh it hurts! 🙂 Here's a peek at the code! I wish the CSS code looked better like in my editor.
 
@@ -177,7 +166,6 @@ Why can't I just say `nth-child(2)` in some generic way so whatever the second e
 
 <Info>
 
-
 ```css
 > :nth-child(2) {
   margin-top: 0;
@@ -188,11 +176,9 @@ Just did this in an Info TextBlock to see how code looks inside them! This style
 
 </Info>
 
-
 With a header, it looks much better. Even with a level 5 header!
 
 <Info>
-
 
 ##### This time with header level 5
 
@@ -200,10 +186,9 @@ An informative item with **_markdown_** formatting (minor such that it is) to re
 
 </Info>
 
-
 <Warning>
-  Last one, I promise. This time, it is just straight-up text without markdown. Looks lovely, just like I want it to
-  look!
+  Last one, I promise. This time, it is just straight-up text without markdown. Looks
+  lovely, just like I want it to look!
 </Warning>
 
 ##### Attributions

--- a/content/collections/blog.mdx
+++ b/content/collections/blog.mdx
@@ -2,6 +2,7 @@
 title: Ken's Blog
 name: blog
 coverImage: ./blog-cover.jpg
+coverAlt: Bright sunset over the ocean as the waves crash into the rocky shore. Foreground has trees and green plants
 ---
 
 Hi all! This blog will be for sharing what I learn, techniques for creating, observations, and perhaps silly stories. I really don't have a guiding principle of what goes here just yet! So far my ideas are:

--- a/content/collections/project.mdx
+++ b/content/collections/project.mdx
@@ -2,6 +2,7 @@
 title: Projects / Creations
 name: project
 coverImage: ./project-cover.jpg
+coverAlt: Close up of a MOOG modular synthesizer with lots of knobs and patch cables
 ---
 
 Hi all! This will be the home for anything I create that can be used in some fashion by others. I'll have a nice little post about it as well as whatever the thingy is!

--- a/content/collections/site.mdx
+++ b/content/collections/site.mdx
@@ -2,6 +2,7 @@
 title: Site Development
 name: site
 coverImage: ./site-cover.jpg
+coverAlt: Construction workers in the midst of building a building
 ---
 
 Hi all! Twenty-four years ago, a much younger man got his first and only domain, `koamar.com`. Since then, it's gone from trying out goofy things with FrontPage (I know!) to a straight up message of defeat.

--- a/content/project/2022/06-23-twelve-chord-tune/index.mdx
+++ b/content/project/2022/06-23-twelve-chord-tune/index.mdx
@@ -4,6 +4,7 @@ slug: twelve-chord-tune
 date: 2022-06-23
 updated: 2022-06-30
 coverImage: ./trevor-kay-I8wigxgi5Kg-unsplash.jpg
+coverAlt: The rock formation known as the twelve apostles. Ocean waves passing huge rock formations and ending on a tranquil beach.
 excerpt: An experiment that turned out fairly well I think
 tags: [music, jazz]
 ---

--- a/content/project/2022/06-29-safe/index.mdx
+++ b/content/project/2022/06-29-safe/index.mdx
@@ -4,6 +4,7 @@ slug: safe
 date: 2022-06-29
 updated: 2022-06-30
 coverImage: ./safe.png
+coverAlt: First two staves of the soprano sax part for the piece Safe for Jazz Octet. Composed and arranged by Ken Feliciano. Style is Gently. Key signature is A. Time signature is 7 / 8.
 excerpt: My first real tune, written back in the 80's
 tags: [music, jazz]
 ---

--- a/content/site/2020/12-11-initial-setup/index.mdx
+++ b/content/site/2020/12-11-initial-setup/index.mdx
@@ -3,6 +3,7 @@ title: Initial Barebones Setup
 slug: initial-setup
 date: 2020-12-28
 coverImage: ./danielle-macinnes-IuLgi9PWETU-unsplash.jpg
+coverAlt: A mug on a table that reads BEGIN.
 excerpt: The implementation of a site for a 24 year old domain begins!
 tags: [gatsby, ftp, git-files]
 implementation: 2020-12-11
@@ -124,21 +125,21 @@ The first time I ran the CI action, it failed. The initial `package.json` contai
 
 ## Retrospective
 
-[X] Initial Setup
+✅ Initial Setup
 
-[X] Lighthouse - go Gatsby!
+✅ Lighthouse - go Gatsby!
 
-![Initial Lighthouse Score](./lighthouse-score.png)
+![Lighthouse scores showing Performance at 85, Accessibility at 100, Best Practices at 100, SEO at 100, and Progress Web App at ?](./lighthouse-score.png)
 
-[X] CI/CD up and running
+✅ CI/CD up and running
 
-[X] Site migration - migrating nothing is **_so much_** easier than normal data migration projects! Old site linked to Google, new site linked to Google. 🎉
+✅ Site migration - migrating nothing is **_so much_** easier than normal data migration projects! Old site linked to Google, new site linked to Google. 🎉
 
-[ ] Needs a favicon - new issue
+⬜ Needs a favicon - new issue
 
-[ ] PWA - new issue
+⬜ PWA - new issue
 
-[ ] Refactor React imports - new issue
+⬜ Refactor React imports - new issue
 
 ##### Attributions
 

--- a/content/site/2021/01-09-tailwind/index.mdx
+++ b/content/site/2021/01-09-tailwind/index.mdx
@@ -3,6 +3,7 @@ title: Tailwind CSS install
 slug: tailwind-install
 date: 2021-01-09
 coverImage: ./jason-blackeye-nyL-rzwP-Mk-unsplash.jpg
+coverAlt: Wind turbines in a snowy area with a sky that is half blue and half clouds.
 excerpt: Let's use Tailwind! Initial installation with distractions!
 tags: [tailwind, dark-mode]
 implementation: 2020-12-12

--- a/content/site/2021/01-14-tw-dark-mode/index.mdx
+++ b/content/site/2021/01-14-tw-dark-mode/index.mdx
@@ -3,6 +3,7 @@ title: Tailwind - Dark Mode
 slug: tw-dark-mode
 date: 2021-01-14
 coverImage: ./sunset-in-maui.jpg
+coverAlt: Sunset over the ocean with palm tree and railing of lanai in foreground. Island in the background.
 excerpt: It's getting darker...
 tags: [tailwind, dark-mode]
 implementation: 2020-12-12
@@ -15,15 +16,16 @@ implementation: 2020-12-12
 I did a lot of research for implementing Dark Mode and I wanted to do it with Tailwind CSS. Tailwind has its own [implementation](https://tailwindcss.com/docs/dark-mode). I originally had the plan of implementing it like this. However, after researching how most developers were doing this, I saw benefit in using CSS Variables. All of this was new to me. I've never been a web designer and I haven't fully grokked CSS. See the Acknowledgements below for all the sites that gave me clues and information!
 
 <Info>
-  One of the main reasons I went with Tailwind CSS was due to the dark mode support  in 2.0. Ironically
-  (or perhaps not...not an expert on irony) I'm not normally using Tailwind's dark mode Still,
-  I'm enjoying a lot of Tailwind and there is plenty of normal CSS and some styled-components in the site as well!
+  One of the main reasons I went with Tailwind CSS was due to the dark mode support in
+  2.0. Ironically (or perhaps not...not an expert on irony) I'm not normally using
+  Tailwind's dark mode. Still, I'm enjoying a lot of Tailwind and there is plenty of
+  normal CSS and some styled-components in the site as well!
 </Info>
 
 <Warning>
-  One issue I kept running into was if I was using Tailwind with twin.macro, as I thought I must, I was going to be
-  blocked from using Tailwind plugins. I had the idea that I'd use twin.macro so I'd have styled-components and Tailwind
-  for best of both worlds!
+  One issue I kept running into was if I was using Tailwind with twin.macro, as I thought
+  I must, I was going to be blocked from using Tailwind plugins. I had the idea that I'd
+  use twin.macro so I'd have styled-components and Tailwind for best of both worlds!
 </Warning>
 
 I ended up working from [Josh W. Comeau's "The Quest for the Perfect Dark Mode"](https://www.joshwcomeau.com/react/dark-mode/)
@@ -64,7 +66,9 @@ I followed Josh's steps, creating a ThemeContext and learning about React Contex
 
 His function was called `getInitialColorMode` while mine is `getInitialTheme`. They both do the same thing in the long run but since Tailwind was going to handle the colors, I only had to set the theme as `light` or `dark` and set a class on the `body` element.
 
-<Info>This ends up in `gatsby-ssr.js`. Where it is at this moment in history is lost to me!</Info>
+<Info>
+  This ends up in `gatsby-ssr.js`. Where it is at this moment in history is lost to me!
+</Info>
 
 ```js:title=not-final-version.js {26-30}
 import * as React from 'react'
@@ -91,7 +95,7 @@ const MagicScriptTag = () => {
         // color themes, let's default to 'light'.
         return 'light'
       }
-    
+
       const theme = getInitialTheme()
 
       const body = document.body
@@ -121,8 +125,9 @@ Since there will be a light or dark class added to body, I can use CSS Variables
 After that, dark mode worked!
 
 <Info>
-  So, San Jose Sharks fan here... I decided on light and dark themes based on Sharks colors. Really, the teal and orange
-  ones mostly, although, their other colors are `#ffffff` and `#000000` and those make good surface colors!
+  So, San Jose Sharks fan here... I decided on light and dark themes based on Sharks
+  colors. Really, the teal and orange ones mostly, although, their other colors are
+  `#ffffff` and `#000000` and those make good surface colors!
 </Info>
 
 I thought since I'm going with teal for my primary color, perhaps the blue-gray Tailwind color pallette would do well instead of the standard gray. I ended up using hex codes initially instead of Tailwind codes, however, and at the current state of the project (here on 2021-01-14) I'm still not using Tailwind codes.
@@ -212,11 +217,11 @@ const MagicScriptTag = () => {
         // color themes, let's default to 'light'.
         return 'light'
       }
-    
+
       const theme = getInitialTheme()
-      
+
       const root = document.documentElement
-      root.className = theme      
+      root.className = theme
       root.style.setProperty('--initial-theme', theme)
     })()`
 

--- a/content/site/2021/01-18-hero-part-1/index.mdx
+++ b/content/site/2021/01-18-hero-part-1/index.mdx
@@ -3,6 +3,7 @@ title: Hero I
 slug: hero-part-one
 date: 2021-01-18
 coverImage: ./ola-mishchenko-XqYlvd5DGKA-unsplash.jpg
+coverAlt: Two pieces of sandwich with thick bread, lettuce, cheese, meat, and something orange that is not cheese. A chili in the foreground and a glass of water partially in frame.
 excerpt: Add a very simple "Hero"
 tags: [hero]
 implementation: 2020-12-13
@@ -45,9 +46,13 @@ I should apologize for being nebulous here. I've always had problems describing 
 This was quite a quick feature to implement (or was it?!), hence, more of a chatty technical post. I added some text like, "Welcome to KoaMar in 2020, home of Ken Feliciano" and threw in the bullet points from above. When I made the browser window mobile sized, the text was much too busy. I made use of some Tailwind set points to make the text responsive in size and in content.
 
 ```html
-<p className="mt-2 text-3xl leading-8 font-extrabold tracking-tight sm:text-2xl text-body">
+<p
+  className="mt-2 text-3xl leading-8 font-extrabold tracking-tight sm:text-2xl text-body"
+>
   <span className="hidden sm:inline">Lifelong learner</span>
-  <span className="sm:hidden">Learner</span>, musician<span className="md:hidden">, coder</span>
+  <span className="sm:hidden">Learner</span>, musician<span className="md:hidden"
+    >, coder</span
+  >
   <span className="hidden sm:inline">, retired guy</span>
   <span className="hidden md:inline">, some sort of coding type</span>
 </p>

--- a/content/site/2021/02-08-initial-global-styles/index.mdx
+++ b/content/site/2021/02-08-initial-global-styles/index.mdx
@@ -3,6 +3,7 @@ title: Global Styles I
 slug: initial-global-styles
 date: 2021-02-08
 coverImage: ./oscar-obians-QYN7N4sVC4c-unsplash.jpg
+coverAlt: Stylish woman with multi-colored braids against a green forest background
 excerpt: Pick and choose from Gatsby's layout.css
 tags: [css, styled-components, css-variables]
 implementation: 2020-12-18
@@ -20,13 +21,11 @@ In my App component, I had the `ThemeProvider` component wrapping the whole site
 
 <Info>
 
-
 ### Keeping it DRY-er
 
 This had the added benefit of removing some code duplication! When working through the Skillthrive tutorial, [Gatsby JS: Build a Blog](https://www.youtube.com/playlist?list=PLW0RabRDhwwzVNhlOgQQgw6HJzXdM1MnT), I ended up with duplicate code in `gatsby-ssr.js` and `gatsby-browser.js`. Using the App component in those two files allows the code to live only in one place.
 
 </Info>
-
 
 I did not want to try and convert all this CSS into Tailwind at this point since it was **mostly** already done. I knew I liked `styled-components` and I was somewhat familiar with using [createGlobalStyle](https://styled-components.com/docs/api#createglobalstyle) from styled-components. I decided to convert what I needed from layout.css into a GlobalStyles component.
 
@@ -37,7 +36,8 @@ Even though I did not convert this to Tailwind CSS, I knew I was going to try an
 ## Margin Spacing
 
 <Warning>
-  Future me has read about trying to do without margin spacing at all! Present me had not read about it!
+  Future me has read about trying to do without margin spacing at all! Present me had not
+  read about it!
 </Warning>
 
 A lot of Gatsby's initial styling used margin-bottom to separate elements. I had planned on using margin-top. I had experience with it, and to quote something from [Adam Wathan's Tailwind CSS tutorial](https://youtu.be/5byxwJce6zc):
@@ -101,7 +101,7 @@ const GlobalStyles = createGlobalStyle`
       Helvetica Neue, sans-serif;
     font-weight: bold;
     font-size: 1.5rem;
-    line-height: 1;    
+    line-height: 1;
     &:first-child {
       margin-top: 0;
     }
@@ -116,7 +116,7 @@ const GlobalStyles = createGlobalStyle`
   }
   p {
     margin-top: 1.5rem;
-    color: var(--text-body);    
+    color: var(--text-body);
     &:first-child {
       margin-top: 0;
     }
@@ -137,7 +137,6 @@ export default App
 
 <Primary>
 
-
 ### First game against the dreaded LA Kings tomorrow!
 
 I know it makes no sense but when in Sharks-fan-mode, I despise the LA Kings. I firmly believe that a King fan will despise the SJ Sharks as well. That's just the way it is! Meanwhile, they are both lovely teams with lovely people playing on them.
@@ -146,7 +145,6 @@ I know it makes no sense but when in Sharks-fan-mode, I despise the LA Kings. I 
 - Kings are 3-6-2 (last place in the West)
 
 </Primary>
-
 
 ##### Attributions
 

--- a/content/site/2021/02-19-external-links/index.mdx
+++ b/content/site/2021/02-19-external-links/index.mdx
@@ -3,6 +3,7 @@ title: External Links
 slug: external-links
 date: 2021-02-19
 coverImage: ./kenny-luo-VVpIN609QtY-unsplash.jpg
+coverAlt: Chain link fence with yellow flowers growing on it.
 excerpt: Style external links and make them behave consistently
 tags: [tailwind, css, react]
 implementation: 2020-12-18
@@ -23,9 +24,9 @@ I wanted to do this correctly! I did a bit of research and found that links that
 - [nofollow](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-nofollow)
 
 <Warning>
-  I must admit, even after reading all the docs, I'm still nogrok-ing this stuff. But, I see this as the way to do it
-  properly. Click on this external link and you are in a different world not connected to my site at all. That sounds
-  good!
+  I must admit, even after reading all the docs, I'm still nogrok-ing this stuff. But, I
+  see this as the way to do it properly. Click on this external link and you are in a
+  different world not connected to my site at all. That sounds good!
 </Warning>
 
 ### The React component
@@ -59,7 +60,12 @@ Before jumping ahead to refactoring this thing, what's the CSS that is creating 
 
 ```css
 .border-fadeaway {
-  border-image-source: linear-gradient(to right, var(--primary) 0%, var(--link) 76%, transparent 100%);
+  border-image-source: linear-gradient(
+    to right,
+    var(--primary) 0%,
+    var(--link) 76%,
+    transparent 100%
+  );
   border-image-slice: 0 0 100 0;
 }
 
@@ -74,7 +80,12 @@ It sure looks like I could combine these, add `border-primary` and `border-b-2` 
 
 ```css {4,5}
 .border-fadeaway {
-  border-image-source: linear-gradient(to right, var(--primary) 0%, var(--link) 76%, transparent 100%);
+  border-image-source: linear-gradient(
+    to right,
+    var(--primary) 0%,
+    var(--link) 76%,
+    transparent 100%
+  );
   border-image-slice: 0 0 100 0;
   border-color: var(--primary); /* Tailwind: border-primary */
   border-bottom-width: 2px; /* Tailwind: border-b-2 */
@@ -89,7 +100,12 @@ With `border-fadeaway` handling all the border styles and not worrying about Tai
 import * as React from 'react'
 
 export const ExternalLink = ({ href, children }) => (
-  <a href={href} className='inline-link border-fadeaway' target='_blank' rel='noreferrer noopener nofollow'>
+  <a
+    href={href}
+    className='inline-link border-fadeaway'
+    target='_blank'
+    rel='noreferrer noopener nofollow'
+  >
     {children}
   </a>
 )
@@ -101,7 +117,6 @@ I liked this fadeaway border so much I added it to the Header component!
 
 <Primary>
 
-
 #### Ahem, this is my theory... How to win the Stanley Cup
 
 I shout it at my TV a lot but I think I should document it here, in this rarely seen corner of the Internet, where no Sharks coach, GM, or player will probably ever see it.
@@ -111,7 +126,6 @@ If the Sharks want to win the Stanley Cup. All they have to do is...Win every ga
 🏒 Strategy!
 
 </Primary>
-
 
 ##### Attributions
 

--- a/content/site/2022/01-14-google-fonts/index.mdx
+++ b/content/site/2022/01-14-google-fonts/index.mdx
@@ -3,6 +3,7 @@ title: Google Fonts
 slug: google-fonts
 date: 2022-01-14
 coverImage: ./alexander-andrews-RCqVEA9cEVI-unsplash.jpg
+coverAlt: Cover a book titled THE FIELD GUIDE TO TYPOGRAPHY - TYPEFACES IN THE URBAN LANDSCAPE. There are binoculars on the cover. To the right, is a box letters.
 excerpt: Configuring Google Fonts and selecting which fonts to use
 tags: [font, design]
 implementation: 2020-12-19
@@ -10,11 +11,9 @@ implementation: 2020-12-19
 
 <Warning>
 
-
 This implementation happened in Gatsby 2 days. At the moment, the site is still in Gatsby 2. It is also using the original gatsby-plugin-google-fonts method and not the Google Fonts v2 API.
 
 </Warning>
-
 
 ## Configuring Google Fonts
 
@@ -69,21 +68,19 @@ For Lato, which weights would I require? lato\:400,400i,600,600i,700,700i
 
 <Info>
 
-
 ### First Time?
 
 This is the first time I ever saw these weights for fonts. Hence, I wrote them all out so I would remember them. I came across them later, and yes, I did remember them!
 
 </Info>
 
-
 I don't like Francois One for the header. It has a something-something look. More so, I don't think Lato does it for me as a body text. Look at the "F" in Feliciano!
 
-![](font-test-francois-one-and-lato.png)
+![Text saying Hi All! and Welcome to KoaMar in 2020, home of Ken Feliciano](font-test-francois-one-and-lato.png)
 
 Trying Lato for Headers and Open Sans for body. This looks like a standard pairing in Google Fonts world for Lato. It looks much cleaner. Lato is good as a header. It matches the logo. Open Sans seems much more readable. Haven't tried code yet but hopefully Fira Code will look great with ligatures.
 
-![](font-test-lato-and-open-sans.png)
+![Text saying Hi All! and Welcome to KoaMar in 2020, home of Ken Feliciano](font-test-lato-and-open-sans.png)
 
 ## Final Decision
 
@@ -93,13 +90,11 @@ Trying Lato for Headers and Open Sans for body. This looks like a standard pairi
 
 <Warning>
 
-
 ### One final warning
 
 Yes, I like ligatures. I hear, and even get, the argument for not using them but I think they just look nice and I feel happy seeing them.
 
 </Warning>
-
 
 ##### Attributions
 

--- a/content/site/2022/01-18-content/index.mdx
+++ b/content/site/2022/01-18-content/index.mdx
@@ -3,6 +3,7 @@ title: Content
 slug: content
 date: 2022-01-18
 coverImage: ./niklas-ohlrogge-j-0olYcaihg-unsplash.jpg
+coverAlt: A massive library of books with stairs all over. There are nice sitting areas to read on.
 excerpt: The trials and tribulations of configuring for content
 tags: [gatsby]
 implementation: 2020-12-19
@@ -12,13 +13,11 @@ _This one didn't go as planned!_ Jump to the end [Decisions, Decisions](#decisio
 
 <Warning>
 
-
 This implementation happened in Gatsby 2 days. At the moment, the site is still in Gatsby 2.
 
 Also, I need a plugin so I can link to headings in a document which I have **_not_** installed as of yet! If you want to go to Decisions, Decisions, it's down there a bit...you'll find it!
 
 </Warning>
-
 
 ## Content Configuration
 
@@ -180,17 +179,18 @@ export const CoverImage = ({ fluid }) => {
 
 ## Retrospective
 
-- [ ] Links in Mdx are not styled with `ExternalLink` component. It would be nice not to have to embed that as React component and have it automatically translate the link to it. Clicking on them now does not open a new tab either.
-- [x] If there is no `coverImage`, you're hosed!
-- [ ] Code tests look poor - as expected
-- [ ] Table test looks poor - as expected
-- [ ] Post is not styled that great - Heading 1 and 2 are valid, all other headings are the same.
-- [ ] Horizontal rules do not exist
-- [ ] Quotes aren't happening
-- [ ] Ordered lists have no numbers
-- [x] filenames are off the root instead of blog/first-fake, it is /first-fake. You can enter that in the slug but it would be better not to do that!
-  - in `gatsby-node.js` there is code that takes the slug and creates the path for the page
-  - I've got example code on creating a new Node Field that could be used (collection is a good name!)
+⬜ Links in Mdx are not styled with `ExternalLink` component. It would be nice not to have to embed that as React component and have it automatically translate the link to it. Clicking on them now does not open a new tab either.  
+✅ If there is no `coverImage`, you're hosed!  
+⬜ Code tests look poor - as expected  
+⬜ Table test looks poor - as expected  
+⬜ Post is not styled that great - Heading 1 and 2 are valid, all other headings are the same.  
+⬜ Horizontal rules do not exist  
+⬜ Quotes aren't happening  
+⬜ Ordered lists have no numbers  
+✅ filenames are off the root instead of blog/first-fake, it is /first-fake. You can enter that in the slug but it would be better not to do that!
+
+- in `gatsby-node.js` there is code that takes the slug and creates the path for the page
+- I've got example code on creating a new Node Field that could be used (collection is a good name!)
 
 ##### Attributions
 
@@ -201,13 +201,11 @@ on [Unsplash](https://unsplash.com/s/photos/content?utm_source=unsplash&utm_medi
 
 <Info>
 
-
 ## Optional reading
 
 Yes, I realize the whole site and in fact Internet is optional reading, but this really is! These are just some of the initial thoughts I went through when trying to figure out how to configure the site for content.
 
 </Info>
-
 
 [Back to the top!](#content-configuration)
 

--- a/content/site/2022/01-27-finish-global-styles/index.mdx
+++ b/content/site/2022/01-27-finish-global-styles/index.mdx
@@ -3,6 +3,7 @@ title: Finish Global Styles
 slug: finish-global-styles
 date: 2022-01-27
 coverImage: ./oscar-obians-Drtrwygp7co-unsplash.jpg
+coverAlt: A stylish man wearing glasses on a cell phone
 excerpt: With some content comes great deficiencies
 tags: [css]
 implementation: 2020-12-20

--- a/content/site/2022/02-01-content-wrappers/index.mdx
+++ b/content/site/2022/02-01-content-wrappers/index.mdx
@@ -3,6 +3,7 @@ title: Content Wrappers
 slug: content-wrappers
 date: 2022-02-01
 coverImage: ./visual-stories-micheile-sclZndD-1HQ-unsplash.jpg
+coverAlt: A wrapped package with ribbon, scissors, and decorative plants nearby
 excerpt: Stealing stuff like a great artist...uh-huh
 tags: [twin.macro, tailwind, gatsby]
 implementation: 2020-12-21
@@ -10,18 +11,16 @@ implementation: 2020-12-21
 
 <Info>
 
-
 _Want to see what I stole?_
 
 Jump to [Look out behind you](#look-out-behind-you)
 
 </Info>
 
-
 ## Implementation
 
-- [x] Work on site-wrapper feature
-- [ ] Work on content-wrapper feature (for posts). _Tried to do this with grid but didn't go well and perhaps didn't need it. I left the work in `content-grid` branch._
+✅ Work on site-wrapper feature  
+⬜ Work on content-wrapper feature (for posts). _Tried to do this with grid but didn't go well and perhaps didn't need it. I left the work in `content-grid` branch._
 
 ## Site Wrapper
 
@@ -51,7 +50,9 @@ In Skillthrive, he's putting all styled-components in an elements folder. I like
 
 ```jsx
 import tw, { styled } from 'twin.macro'
-const SiteWrapper = styled.div(() => [tw`h-full m-auto max-w-screen-lg pt-0 px-4 pb-6 mt-6`])
+const SiteWrapper = styled.div(() => [
+  tw`h-full m-auto max-w-screen-lg pt-0 px-4 pb-6 mt-6`,
+])
 ```
 
 ## Content Wrapper
@@ -60,16 +61,14 @@ This one may be involved. It's not really needed in the Layout at the moment, si
 
 <Warning>
 
-
 Didn't go too well with CSS Grid like in the tutorial. Going to try to keep it simpler.
 
 </Warning>
 
-
 ## Retrospective
 
-- [ ] Look for Tailwind ways to make the cover image look better and responsive. I want full bleed width but it isn't perfect.
-- [ ] Add more padding (at least on the X-axis) for content
+⬜ Look for Tailwind ways to make the cover image look better and responsive. I want full bleed width but it isn't perfect.  
+⬜ Add more padding (at least on the X-axis) for content
 
 ##### Attributions
 
@@ -113,7 +112,11 @@ export const Container = ({ children }) => (
 
 ```jsx
 <Container>
-  <Seo title={data.mdx.frontmatter.title} image={seoImage} description={data.mdx.frontmatter.excerpt} />
+  <Seo
+    title={data.mdx.frontmatter.title}
+    image={seoImage}
+    description={data.mdx.frontmatter.excerpt}
+  />
   <FeatureImage fluid={featureImage} />
   <Post>
     <H1 margin='0 0 2rem 0'>{data.mdx.frontmatter.title}</H1>

--- a/content/site/2022/02-14-syntax-highlighting/index.mdx
+++ b/content/site/2022/02-14-syntax-highlighting/index.mdx
@@ -3,6 +3,7 @@ title: Syntax Highlighting
 slug: syntax-highlighting
 date: 2022-02-14
 coverImage: ./syntax-highlighting-example.png
+coverAlt: A dark mode snapshot of code from the site
 excerpt: Implementation of Code System in Blog
 tags: [css, mdx, react, gatsby]
 implementation: 2020-12-22

--- a/content/site/2022/02-21-auto-link-formatting/index.mdx
+++ b/content/site/2022/02-21-auto-link-formatting/index.mdx
@@ -3,6 +3,7 @@ title: Automatic Link Formatting
 slug: auto-link-formatting
 date: 2022-02-21
 coverImage: ./IMAG1150.jpg
+coverAlt: A metal platform of linked six sided matrix at the top of a ladder overlooking the blue ocean.
 excerpt: Making links in Markdown content look and behave like I want
 tags: [react, gatsby]
 implementation: 2020-12-22

--- a/content/site/2022/02-28-post-template/index.mdx
+++ b/content/site/2022/02-28-post-template/index.mdx
@@ -3,6 +3,7 @@ title: Post Template
 slug: post-template
 date: 2022-02-28
 coverImage: ./green-chameleon-s9CC2SKySJM-unsplash.jpg
+coverAlt: A person writing with a blue mechanical pencil wearing a long sleeve light brown and gray shirt or sweater. Only a bit of sleeve is visible. A notebook and coffee mug are in the background.
 excerpt: Creating a template for blog, site, and project posts
 tags: [gatsby]
 implementation: 2020-12-24
@@ -16,11 +17,9 @@ Given all the thoughts below, it seemed like a single template would work. Curre
 
 <Success>
 
-
 Wow, quickest, smallest commit in the whole thing! Probably what most commits should be!
 
 </Success>
-
 
 ### Front Matter Updates
 
@@ -32,11 +31,9 @@ Wow, quickest, smallest commit in the whole thing! Probably what most commits sh
 
 <Info>
 
-
 This is all easily visible on every post.
 
 </Info>
-
 
 ### Updates on cover images
 

--- a/content/site/2022/03-11-react-headroom/index.mdx
+++ b/content/site/2022/03-11-react-headroom/index.mdx
@@ -3,6 +3,7 @@ title: Need some room, at the top
 slug: react-headroom
 date: 2022-03-11
 coverImage: ./jiroe-qAahMC9xLmA-unsplash.jpg
+coverAlt: Two mixing consoles displaying VU meters, lots of knobs, and faders.
 excerpt: So tired of scrolling to top of page.
 tags: [react]
 implementation: 2020-12-26

--- a/content/site/2022/03-15-internal-links/index.mdx
+++ b/content/site/2022/03-15-internal-links/index.mdx
@@ -3,6 +3,7 @@ title: Internal Links
 slug: internal-links
 date: 2022-03-15
 coverImage: ./fre-sonneveld-K8iHtzoIKQ4-unsplash.jpg
+coverAlt: Yellow chains overlaying a dark blue-green background.
 excerpt: First time making a change because of real content!
 tags: [markdown]
 implementation: 2020-12-29

--- a/content/site/2022/03-25-post-list-page/index.mdx
+++ b/content/site/2022/03-25-post-list-page/index.mdx
@@ -3,6 +3,7 @@ title: Post List Page
 slug: post-list-page
 date: 2022-03-25
 coverImage: ./kelly-sikkema--1_RZL8BGBM-unsplash.jpg
+coverAlt: A 3 by 3 matrix of yellow post-it notes on a white background with the last being placed by a barely seen hand
 excerpt: The landing page of each section of the site.
 tags: [gatsby, react]
 implementation: 2020-12-30
@@ -169,8 +170,8 @@ And sometimes, I'm not like that. I also added some default cover pictures for e
 
 ### Tasks
 
-- [ ] coverImage should come from Mdx
-- [ ] Page content should come from Mdx
+⬜ coverImage should come from Mdx  
+⬜ Page content should come from Mdx
 
 ## 2022 Retrospective
 

--- a/content/site/2022/03-29-section-content/index.mdx
+++ b/content/site/2022/03-29-section-content/index.mdx
@@ -3,6 +3,7 @@ title: Section Content
 slug: section-content
 date: 2022-03-29
 coverImage: ./skye-studios-NDLLFxTELrU-unsplash.jpg
+coverAlt: A view from below of spheres with lights connected to long strings hanging from the ceiling.
 excerpt: Wherein each section of the site gets content!
 tags: [gatsby, mdx]
 implementation: 2020-12-31
@@ -28,9 +29,10 @@ The body will be the description of the section and will appear before links to 
 
 ### Retrospective
 
-- [ ] Add pagination component for when there are more than 6 entries
-- [ ] Need light side branded surface for when there is no cover image
-- [ ] Create Card components for posts and format them better, perhaps two columns for larger, one column for mobile.
+⬜ Add pagination component for when there are more than 6 entries  
+⬜ Need light side branded surface for when there is no cover image  
+⬜ Create Card components for posts and format them better, perhaps two columns for larger, one column for mobile.
+
 - **For Mobile**
   - Picture full width of container
   - Title

--- a/content/site/2022/04-04-site-menu/index.mdx
+++ b/content/site/2022/04-04-site-menu/index.mdx
@@ -3,6 +3,7 @@ title: Menu
 slug: site-menu
 date: 2022-04-04
 coverImage: ./croissant-QIXmEEzgu-M-unsplash.jpg
+coverAlt: Menu at a coffee shop displaying various drinks and their price. In the background, there is a statue of a pigeon looking at us.
 excerpt: Adding a menu to the site
 tags: [react, tailwind-css, svg]
 implementation: 2021-01-01

--- a/content/site/2022/04-11-new-hero/index.mdx
+++ b/content/site/2022/04-11-new-hero/index.mdx
@@ -3,6 +3,7 @@ title: New Hero
 slug: new-hero
 date: 2022-04-11
 coverImage: ./gabriel-bassino-zEawlLdVloo-unsplash.jpg
+coverAlt: A neon sign that reads WE CAN BE HEROES JUST FOR ONE DAY
 excerpt: A new hero (component) arrives
 tags: [gatsby, css, react]
 implementation: 2021-01-01
@@ -77,15 +78,15 @@ I also wanted to be able to pass in a maxWidth but I couldn't see a way to do th
 
 I started with the primary Sharks colors for the background. They seemed a bit bright.
 
-![Sharks Orange Version](hero-sharks-orange.png)
+![Hero image with Sharks orange background and black text that says Lifelong learner, musician, retired guy, some sort of coding type](hero-sharks-orange.png)
 
-![Sharks Teal Version](hero-sharks-teal.png)
+![Hero image with Sharks teal background and white text that says Lifelong learner, musician, retired guy, some sort of coding type](hero-sharks-teal.png)
 
 I decided to try this branded surface idea. For dark mode, this is a real thing I believe. I did not do anything official, just tossed my primary colors into [Convert a Color](http://convertacolor.com), lowered the lightness to 6% and I got a decent really dark teal. I did this for the Sharks orange color too and got a nice dark orange but that doesn't make sense for light mode. I tried 80% instead and got a very light orange.
 
-![Sharks Lighter Orange Version](hero-lighter-orange.png)
+![Hero image with a lighter version of Sharks orange background and black text that says Lifelong learner, musician, retired guy, some sort of coding type](hero-lighter-orange.png)
 
-![Sharks Darker Teal Version](hero-darker-teal.png)
+![Hero image with a darker version of Sharks teal background and white text that says Lifelong learner, musician, retired guy, some sort of coding type](hero-darker-teal.png)
 
 I'm really not sure which one I like better. I almost like the light orange and the original Sharks Teal best! Hmm, I can do that with Tailwind even though I'm using CSS variables.
 

--- a/content/site/2022/04-18-post-card/index.mdx
+++ b/content/site/2022/04-18-post-card/index.mdx
@@ -3,6 +3,7 @@ title: Post Card Component
 slug: post-card
 date: 2022-04-18
 coverImage: ./becky-phan-BVYRU3aFKsU-unsplash.jpg
+coverAlt: A pile of postcards that one would get while on vacation scattered and piled on a surface
 excerpt: Each post gets its own little card to shine
 tags: [tailwind-css]
 implementation: 2021-01-02
@@ -27,10 +28,10 @@ Instead of mapping over a bunch of HTML, extract out the div with all its childr
 ## Mobile Design
 
 _Current Design - Large Device_
-![Current Design](01-current-design.png)
+![Post object with example picture on the left and title, excerpt, and date on the right](01-current-design.png)
 
 _Current Design - Mobile_ with picture on the top
-![Mobile As-Is](02-mobile-as-is.png)
+![Post object shrunken to show how it would appear on mobile devices](02-mobile-as-is.png)
 
 ### Picture Adjustments
 
@@ -39,20 +40,20 @@ Picture needs to be larger at this point. It should fill the entire top of the c
 Instead of `flex-row`, which is fine for desktop, change to `flex-col` and use `sm:flex-row` for desktop sizes.
 
 The image will now be `w-auto h-auto` and `sm:w-36 sm:h-24`. So it fills the card nicely on mobile and still looks good on desktop.
-![Mobile Picture Larger](03-mobile-picture-larger.png)
+![Post object with picture sized to fill up the whole width ](03-mobile-picture-larger.png)
 
 Doing this for the placeholder does not go so well when it is not an image. However, it's not atrocious just having a card with no image for a mobile. Chances are, this will not happen.
-![Mobile with no picture](04-mobile-no-picture.png)
+![Post object when there is no picture on mobile device. It only shows title, excerpt, and date](04-mobile-no-picture.png)
 
 That may be a big large for a phone, although it does look okay when using responsive tools in Chrome.
 
 ### Typography Adjustment
 
 Most a pity, the other text like heading and such looks too large on a phone.
-![Mobile - Font Size Issues](05-mobile-galaxy-fold.png)
+![Post object displaying words that are too long](05-mobile-galaxy-fold.png)
 
 Granted this is a Galaxy Fold. All the other phone options look alright. But…
-![Mobile - Site development header](06-site-development-header-mobile.png)
+![Post object displaying header that is too long](06-site-development-header-mobile.png)
 
 Options are to lower the font size (probably need to do that) and perhaps remove or lessen the margin around the container.
 
@@ -62,7 +63,7 @@ Now that the second flex part is below the picture, the bit of left margin is no
 
 The text is too close to the picture now so it'll need a bit of top margin, only for mobile. Updating that to `mt-2 sm:mt-0`.
 
-![Mobile final fixed version](07-mobile-fixed.png)
+![Post object that has properly sized header and text](07-mobile-fixed.png)
 
 ## Make Whole Card Clickable
 

--- a/content/site/2022/04-25-two-column-layout/index.mdx
+++ b/content/site/2022/04-25-two-column-layout/index.mdx
@@ -3,6 +3,7 @@ title: Two Column Layout on Large Screen
 slug: two-column-layout
 date: 2022-04-25
 coverImage: ./hisham-zayadnh-oFHBH0W3vRY-unsplash.jpg
+coverAlt: Part of an ancient building with many columns making a curve
 excerpt: Getting to Grid for the first time
 tags: [tailwind, css]
 implementation: 2022-01-02
@@ -11,7 +12,7 @@ implementation: 2022-01-02
 ## Initial Thoughts
 
 I'm used to using Flexbox for everything. So, that is the road I went down. I could not seem to get what I wanted, which is this, using Tailwind CSS!
-![Two Columns for Posts](two-column-layout.png)
+![Three post objects showing a picture, title, excerpt, and date and how it would look with two columns](two-column-layout.png)
 
 Using Flexbox made it flexible but I wanted them equal too. I thought, well flex-basis would do the trick, but I didn't see that in Tailwind. It sure looked like a grid though, so, switched to using grid!
 

--- a/content/site/2022/05-02-link-to-headers/index.mdx
+++ b/content/site/2022/05-02-link-to-headers/index.mdx
@@ -3,6 +3,7 @@ title: Link to headers
 slug: link-to-headers
 date: 2022-05-02
 coverImage: ./teddy-bear-at-rehearsal.jpg
+coverAlt: A teddy bear, wearing Ray Ban sunglasses, sticking it's head out of an upright piano. A piece of piano music is in the lower right corner.
 excerpt: Navigation within a page via headers is cool
 tags: [mdx, gatsby, javascript]
 implementation: 2022-01-18

--- a/content/site/2022/05-11-style-checkboxes/index.mdx
+++ b/content/site/2022/05-11-style-checkboxes/index.mdx
@@ -3,6 +3,7 @@ title: Style Checkboxes
 slug: style-checkboxes
 date: 2022-05-11
 coverImage: ./brett-jordan-ehKaEaZ5VuU-unsplash.jpg
+coverAlt: Wooden scrabble tiles spelling out LEARN FROM FAILURE with one word stacked the other
 excerpt: My first (or second) failure
 tags: [markdown, css]
 implementation: 2022-02-08

--- a/content/site/2022/05-24-update-dependencies/index.mdx
+++ b/content/site/2022/05-24-update-dependencies/index.mdx
@@ -3,6 +3,7 @@ title: Update Dependencies - Fail
 slug: update-dependencies
 date: 2022-05-24
 coverImage: ./sarah-kilian-52jRtc2S_VE-unsplash.jpg
+coverAlt: A sugar ice cream cone that is lying on the ground, a dollop of ice cream that appears to be vanilla with brownies in it lying next to it.
 excerpt: Trying to update dependencies
 tags: [:array-of-tags]
 implementation: 2022-01-11

--- a/content/site/2022/05-30-gatsby-2-to-4/index.mdx
+++ b/content/site/2022/05-30-gatsby-2-to-4/index.mdx
@@ -3,6 +3,7 @@ title: Update Gatsby 2 to 4
 slug: gatsby-2-to-4
 date: 2022-05-30
 coverImage: ./undraw_gatsbyjs_st4g.png
+coverAlt: A drawing of a person with short dark hair, long dark pants, and a purple shirt standing between the Gatsby logo and the word Gatsby
 excerpt: Updating Gatsby success story!
 tags: [gatsby, styled-components, npm]
 implementation: 2022-03-18

--- a/src/components/CoverImage.js
+++ b/src/components/CoverImage.js
@@ -2,8 +2,7 @@ import * as React from 'react'
 import { GatsbyImage } from 'gatsby-plugin-image'
 import { useStaticQuery, graphql } from 'gatsby'
 
-export const CoverImage = ({ fluid }) => {
-  console.log(fluid)
+export const CoverImage = ({ fluid, alt }) => {
   const data = useStaticQuery(graphql`
     query {
       imageSharp(
@@ -13,12 +12,13 @@ export const CoverImage = ({ fluid }) => {
       }
     }
   `)
-  console.log(data.imageSharp.gatsbyImageData)
+
   return (
     <div className='relative h-auto m-auto overflow-hidden md:h-96'>
       <GatsbyImage
         image={fluid ? fluid : data.imageSharp.gatsbyImageData}
         className='absolute top-0 left-0 w-full h-full'
+        alt={alt}
       />
     </div>
   )

--- a/src/components/PostCard.js
+++ b/src/components/PostCard.js
@@ -21,6 +21,7 @@ export const PostCard = ({ post, collection }) => (
         <GatsbyImage
           image={post.node.frontmatter.coverImage.childImageSharp.gatsbyImageData}
           className='top-0 left-0 flex-none w-auto h-auto sm:w-36 sm:h-24'
+          alt={post.node.frontmatter.coverAlt}
         />
       ) : (
         <div className='bg-brandedSurface sm:w-36 sm:h-24'></div>

--- a/src/templates/post-list.js
+++ b/src/templates/post-list.js
@@ -22,7 +22,10 @@ const postList = ({ pageContext, data }) => {
   return (
     <Layout>
       <SEO />
-      <CoverImage fluid={site.frontmatter.coverImage.childImageSharp.gatsbyImageData} />
+      <CoverImage
+        fluid={site.frontmatter.coverImage.childImageSharp.gatsbyImageData}
+        alt={site.frontmatter.coverAlt}
+      />
       <Content>
         <h1>{site.frontmatter.title}</h1>
         {currentPage === 1 && <MDXRenderer>{site.body}</MDXRenderer>}
@@ -39,49 +42,55 @@ const postList = ({ pageContext, data }) => {
         nextPage={nextPage}
       />
     </Layout>
-  );
+  )
 }
 
 export default postList
 
-export const pageQuery = graphql`query AllPostsQuery($skip: Int!, $limit: Int!, $collection: String!) {
-  allMdx(
-    sort: {fields: frontmatter___date, order: DESC}
-    filter: {fields: {collection: {eq: $collection}}, frontmatter: {draft: {eq: false}}}
-    skip: $skip
-    limit: $limit
-  ) {
-    edges {
-      node {
-        frontmatter {
-          slug
-          title
-          date(formatString: "MMMM D, YYYY")
-          updated(formatString: "MMMM D, YYYY")
-          excerpt
-          coverImage {
-            publicURL
-            childImageSharp {
-              gatsbyImageData(layout: FULL_WIDTH)
+export const pageQuery = graphql`
+  query AllPostsQuery($skip: Int!, $limit: Int!, $collection: String!) {
+    allMdx(
+      sort: { fields: frontmatter___date, order: DESC }
+      filter: {
+        fields: { collection: { eq: $collection } }
+        frontmatter: { draft: { eq: false } }
+      }
+      skip: $skip
+      limit: $limit
+    ) {
+      edges {
+        node {
+          frontmatter {
+            slug
+            title
+            date(formatString: "MMMM D, YYYY")
+            updated(formatString: "MMMM D, YYYY")
+            excerpt
+            coverAlt
+            coverImage {
+              publicURL
+              childImageSharp {
+                gatsbyImageData(layout: FULL_WIDTH)
+              }
             }
           }
-        }
-        id
-        excerpt
-      }
-    }
-  }
-  mdx(frontmatter: {name: {eq: $collection}}) {
-    body
-    frontmatter {
-      title
-      coverImage {
-        publicURL
-        childImageSharp {
-          gatsbyImageData(layout: FULL_WIDTH)
+          id
+          excerpt
         }
       }
     }
+    mdx(frontmatter: { name: { eq: $collection } }) {
+      body
+      frontmatter {
+        title
+        coverAlt
+        coverImage {
+          publicURL
+          childImageSharp {
+            gatsbyImageData(layout: FULL_WIDTH)
+          }
+        }
+      }
+    }
   }
-}
 `

--- a/src/templates/single-post.js
+++ b/src/templates/single-post.js
@@ -43,7 +43,10 @@ const getThirdField = ({ implementation, created, createdCirca, date }) => {
 
 const BlogPost = ({ data, pageContext }) => {
   const frontmatter = data.mdx.frontmatter
-  const coverImage = frontmatter.coverImage ? frontmatter.coverImage.childImageSharp.gatsbyImageData : null
+  const coverImage = frontmatter.coverImage
+    ? frontmatter.coverImage.childImageSharp.gatsbyImageData
+    : null
+  const coverAlt = frontmatter.coverAlt
   const thirdField = getThirdField(frontmatter)
   const collection = data.mdx.fields.collection
   const nextPost = pageContext.next
@@ -52,7 +55,7 @@ const BlogPost = ({ data, pageContext }) => {
   return (
     <Layout>
       <SEO title={frontmatter.title} description={frontmatter.excerpt} />
-      <CoverImage fluid={coverImage} />
+      <CoverImage fluid={coverImage} alt={coverAlt} />
       <div className='flex items-center justify-between mt-1 ml-2 mr-2 text-xs lg:items-start lg:text-sm text-muted lg:ml-0 lg:mr-0'>
         <InfoWrapper>
           <span>Posted </span>
@@ -69,11 +72,15 @@ const BlogPost = ({ data, pageContext }) => {
       <Content>
         <h1>
           {frontmatter.draft && (
-            <span className='inline-block p-2 tracking-wide uppercase rounded-lg bg-opposite'>(Draft)</span>
+            <span className='inline-block p-2 tracking-wide uppercase rounded-lg bg-opposite'>
+              (Draft)
+            </span>
           )}{' '}
           {frontmatter.title}
         </h1>
-        {frontmatter.updated ? <p className='mt-1 text-sm text-muted'>Updated: {frontmatter.updated}</p> : null}
+        {frontmatter.updated ? (
+          <p className='mt-1 text-sm text-muted'>Updated: {frontmatter.updated}</p>
+        ) : null}
         <MDXRenderer>{data.mdx.body}</MDXRenderer>
       </Content>
       <LinkEdges prevPage={prevPost} nextPage={nextPost} collection={collection} />
@@ -83,31 +90,33 @@ const BlogPost = ({ data, pageContext }) => {
 
 export default BlogPost
 
-export const blogQuery = graphql`query SinglePostQuery($id: String!) {
-  mdx(id: {eq: $id}) {
-    body
-    frontmatter {
-      date(formatString: "MM/DD/YYYY")
-      updated(formatString: "MM/DD/YYYY")
-      excerpt
-      slug
-      title
-      tags
-      draft
-      implementation(formatString: "MM/DD/YYYY")
-      created(formatString: "MM/DD/YYYY")
-      createdCirca
-      coverImage {
-        publicURL
-        childImageSharp {
-          gatsbyImageData(layout: FULL_WIDTH)
+export const blogQuery = graphql`
+  query SinglePostQuery($id: String!) {
+    mdx(id: { eq: $id }) {
+      body
+      frontmatter {
+        date(formatString: "MM/DD/YYYY")
+        updated(formatString: "MM/DD/YYYY")
+        excerpt
+        slug
+        title
+        tags
+        draft
+        implementation(formatString: "MM/DD/YYYY")
+        created(formatString: "MM/DD/YYYY")
+        createdCirca
+        coverAlt
+        coverImage {
+          publicURL
+          childImageSharp {
+            gatsbyImageData(layout: FULL_WIDTH)
+          }
         }
       }
-    }
-    timeToRead
-    fields {
-      collection
+      timeToRead
+      fields {
+        collection
+      }
     }
   }
-}
 `


### PR DESCRIPTION
Add alternate text for all images using `coverAlt` YAML field. Updated all posts that had a `coverImage` which is 99% of them.
Also made all the checkboxes consistent! I wasn't supposed to do that in this update but there you have it.